### PR TITLE
fixed bug where destroy user didnt fully destroy user comments

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,9 +6,7 @@ class DashboardController < ApplicationController
 
   def destroy
     @user = User.find(params[:id])
-    @user.comments.each do |comment|
-      comment.destroy
-    end
+    @user.comments.each(&:destroy)
     if_admin = current_user.admin?
     @user.destroy
     if if_admin

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,10 +6,11 @@ class DashboardController < ApplicationController
 
   def destroy
     @user = User.find(params[:id])
-    @comments = @user.comments
+    @user.comments.each do |comment|
+      comment.destroy
+    end
     if_admin = current_user.admin?
     @user.destroy
-    @comments.destroy
     if if_admin
       redirect_to dashboard_index_path, notice: 'User deleted' if @user.destroy
     else


### PR DESCRIPTION
because it turns out you need to iterate over comments to destroy every comment. can't just do comments.destroy :\